### PR TITLE
fix: Fix Linux tray menu and Settings window EventLoop issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ eframe = { version = "0.29", features = ["persistence"] }
 tray-icon = "0.19"
 notify-rust = "4.11"
 image = "0.25"
+winit = { version = "0.30", features = ["x11"] }
 
 # System monitoring
 sysinfo = "0.32"

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
     info!("System tray initialized");
 
     // Create settings window (but don't show it yet)
-    let settings_window = Arc::new(SettingsWindow::new());
+    let settings_window = Arc::new(SettingsWindow::new()?);
 
     // Create notification manager
     let notif_manager = Arc::new(NotificationManager::new());
@@ -92,11 +92,10 @@ async fn main() -> Result<()> {
                         ui::tray::TrayMessage::OpenSettings => {
                             info!("Opening settings window");
                             let settings_clone = settings_window_clone.clone();
-                            // Run settings window in a separate thread
-                            std::thread::spawn(move || {
-                                settings_clone.show();
-                                if let Err(e) = settings_clone.run() {
-                                    error!("Failed to run settings window: {}", e);
+                            // Show the settings window
+                            tokio::spawn(async move {
+                                if let Err(e) = settings_clone.show().await {
+                                    error!("Failed to show settings window: {}", e);
                                 }
                             });
                         }


### PR DESCRIPTION
## Summary
This PR fixes two critical issues on Linux that prevented proper UI functionality:
- 🐛 Tray menu not opening when clicked
- 🐛 Settings window EventLoop recreation error

## Problems Solved

### 1. Tray Menu Not Opening on Linux
**Issue**: The tray menu wouldn't open when clicked on Linux/GNOME systems.
**Root Cause**: Menu event polling was happening in a separate thread without GTK context.
**Solution**: 
- Moved menu event handling to GTK idle callback
- Created Linux-specific implementation with proper GTK integration
- Events now processed within the GTK main loop

### 2. Settings Window EventLoop Error
**Issue**: "EventLoop can't be recreated" error when trying to open Settings multiple times.
**Root Cause**: eframe creates an EventLoop that persists, preventing recreation.
**Solution**:
- Implemented deferred window creation (waits for first Show command)
- Added persistent EventLoop with channel-based communication
- Window no longer opens blank at startup
- Added Linux X11 thread compatibility

## Changes
- ✅ Added `winit` dependency with x11 feature for Linux
- ✅ Restructured tray icon creation for Linux with GTK integration
- ✅ Settings window now uses persistent EventLoop approach
- ✅ Fixed blank window opening at startup
- ✅ Added foundation for window icon support

## Testing
- Tested on Linux (Ubuntu with GNOME)
- Tray menu opens correctly on click
- Settings window can be opened multiple times without errors
- No blank window at startup

## Screenshots
- Tray menu working properly
- Settings window opening with correct UI

🤖 Generated with [Claude Code](https://claude.ai/code)